### PR TITLE
[#7] Parse Request URL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+regex="1.3.9"
+lazy_static="1.4.0"
 
 [dev-dependencies]

--- a/src/http/http_error.rs
+++ b/src/http/http_error.rs
@@ -1,5 +1,5 @@
 #[derive(Debug)]
-pub enum HttpParseError {
+pub enum HttpError {
     ExceedCapacity,
     HeaderParseError,
     BodyReadError,

--- a/src/http/http_request.rs
+++ b/src/http/http_request.rs
@@ -1,15 +1,36 @@
-use crate::http::{HttpRequestBody, HttpRequestHeader};
+use std::convert::TryInto;
 
+use crate::http::{HttpError, HttpRequestBody, HttpRequestHeader};
+use crate::url::url_path::UrlPath;
+
+#[derive(Debug)]
 pub struct HttpRequest {
+    req_path: UrlPath,
     header: HttpRequestHeader,
     body: Option<HttpRequestBody>,
 }
 
 impl HttpRequest {
-    pub fn new(header: HttpRequestHeader, body: Option<HttpRequestBody>) -> Self {
-        HttpRequest {
+    pub fn new(
+        header: HttpRequestHeader,
+        body: Option<HttpRequestBody>,
+    ) -> Result<Self, HttpError> {
+        let req_path: UrlPath = if let Ok(req_path) = (&header).try_into() {
+            req_path
+        } else {
+            return Err(HttpError::HeaderParseError);
+        };
+
+        // let req_path: UrlPath = if let Ok(req_path: UrlPath) = header.try_into() {
+        //     req_path
+        // } else {
+        //     return Err(HttpError::HeaderParseError);
+        // };
+
+        Ok(HttpRequest {
+            req_path,
             header,
             body,
-        }
+        })
     }
 }

--- a/src/http/http_request.rs
+++ b/src/http/http_request.rs
@@ -21,12 +21,6 @@ impl HttpRequest {
             return Err(HttpError::HeaderParseError);
         };
 
-        // let req_path: UrlPath = if let Ok(req_path: UrlPath) = header.try_into() {
-        //     req_path
-        // } else {
-        //     return Err(HttpError::HeaderParseError);
-        // };
-
         Ok(HttpRequest {
             req_path,
             header,

--- a/src/http/http_request_body.rs
+++ b/src/http/http_request_body.rs
@@ -1,3 +1,4 @@
+#[derive(Debug)]
 pub struct HttpRequestBody {
     raw: Vec<u8>
 }

--- a/src/http/http_request_header.rs
+++ b/src/http/http_request_header.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
 
-use crate::http::HttpParseError;
+use crate::http::HttpError;
 use crate::http::method::HttpMethod;
 use crate::http::version::HttpVersion;
 use crate::util::lines::Lines;
@@ -25,12 +25,16 @@ impl HttpRequestHeader {
         self.method == HttpMethod::POST
     }
 
+    pub fn get_req_url(&self) -> &str {
+        &self.req_url
+    }
+
     pub fn get_content_length(&self) -> Option<usize> {
         self.get_header("content-length")
     }
 }
 
-trait ReadHeaderAs<T> {
+pub trait ReadHeaderAs<T> {
     fn get_header(&self, key: &str) -> Option<T>;
 }
 
@@ -59,14 +63,14 @@ impl ReadHeaderAs<String> for HttpRequestHeader {
 }
 
 impl TryFrom<Vec<u8>> for HttpRequestHeader {
-    type Error = HttpParseError;
+    type Error = HttpError;
 
     fn try_from(raw: Vec<u8>) -> Result<Self, Self::Error> {
         let mut lines = Lines::new(raw);
         let (method, req_url, version) = if let Some(start_line) = lines.next() {
             parse_start_line(start_line)?
         } else {
-            return Err(HttpParseError::HeaderParseError);
+            return Err(HttpError::HeaderParseError);
         };
 
         let headers = parse_header(&mut lines)?;
@@ -92,7 +96,7 @@ type Method = String;
 type Url = String;
 type Version = String;
 
-fn parse_start_line(first_line: String) -> Result<(Method, Url, Version), HttpParseError> {
+fn parse_start_line(first_line: String) -> Result<(Method, Url, Version), HttpError> {
     let mut split = first_line.split(' ');
     let method = split.next();
     let req_url = split.next();
@@ -101,11 +105,11 @@ fn parse_start_line(first_line: String) -> Result<(Method, Url, Version), HttpPa
     if let (Some(method), Some(req_url), Some(version)) = (method, req_url, version) {
         Ok((method.to_string(), req_url.to_string(), version.to_string()))
     } else {
-        Err(HttpParseError::HeaderParseError)
+        Err(HttpError::HeaderParseError)
     }
 }
 
-fn parse_header(raw: &mut Lines) -> Result<HashMap<String, String>, HttpParseError> {
+fn parse_header(raw: &mut Lines) -> Result<HashMap<String, String>, HttpError> {
     let mut header_map = HashMap::<String, String>::new();
 
     for line in raw {
@@ -119,7 +123,7 @@ fn parse_header(raw: &mut Lines) -> Result<HashMap<String, String>, HttpParseErr
                 value.trim().to_string(),
             );
         } else {
-            return Err(HttpParseError::HeaderParseError);
+            return Err(HttpError::HeaderParseError);
         }
     }
 
@@ -131,7 +135,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_parse_start_line() -> Result<(), HttpParseError> {
+    fn test_parse_start_line() -> Result<(), HttpError> {
         let raw = Vec::from("GET /hello HTTP/1.1\r\nHost: 127.0.0.1:8888".as_bytes());
         let mut lines = Lines::new(raw);
         let (method, path, version) = parse_start_line(lines.next().unwrap())?;

--- a/src/http/method.rs
+++ b/src/http/method.rs
@@ -1,6 +1,6 @@
 use std::convert::TryFrom;
 
-use crate::http::HttpParseError;
+use crate::http::HttpError;
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum HttpMethod {
@@ -9,7 +9,7 @@ pub enum HttpMethod {
 }
 
 impl TryFrom<String> for HttpMethod {
-    type Error = HttpParseError;
+    type Error = HttpError;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
         let value = value.to_lowercase();
@@ -17,7 +17,7 @@ impl TryFrom<String> for HttpMethod {
         match value.as_str() {
             "get" => Ok(HttpMethod::GET),
             "post" => Ok(HttpMethod::POST),
-            _ => Err(HttpParseError::HeaderParseError)
+            _ => Err(HttpError::HeaderParseError)
         }
     }
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,4 +1,4 @@
-pub use http_parse_error::HttpParseError;
+pub use http_error::HttpError;
 pub use http_request::HttpRequest;
 pub use http_request_body::HttpRequestBody;
 pub use http_request_header::HttpRequestHeader;
@@ -7,7 +7,7 @@ mod version;
 
 mod http_request_header;
 mod http_request_body;
-mod http_parse_error;
+mod http_error;
 mod http_request;
 
 pub mod method;

--- a/src/http/version.rs
+++ b/src/http/version.rs
@@ -1,6 +1,6 @@
 use std::convert::{TryFrom, TryInto};
 
-use crate::http::HttpParseError;
+use crate::http::HttpError;
 
 #[derive(Debug, PartialEq)]
 pub enum Protocol {
@@ -17,7 +17,7 @@ pub struct HttpVersion {
 
 
 impl TryFrom<String> for HttpVersion {
-    type Error = HttpParseError;
+    type Error = HttpError;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
         let mut split = value.split('/');
@@ -34,23 +34,23 @@ impl TryFrom<String> for HttpVersion {
                 minor,
             })
         } else {
-            Err(HttpParseError::HeaderParseError)
+            Err(HttpError::HeaderParseError)
         }
     }
 }
 
 impl TryFrom<String> for Protocol {
-    type Error = HttpParseError;
+    type Error = HttpError;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
         match value.to_lowercase().as_ref() {
             "http" => Ok(Protocol::HTTP),
-            _ => Err(HttpParseError::HeaderParseError),
+            _ => Err(HttpError::HeaderParseError),
         }
     }
 }
 
-fn parse_version(value: &str) -> Result<(u8, u8), HttpParseError> {
+fn parse_version(value: &str) -> Result<(u8, u8), HttpError> {
     let mut split = value.split('.');
     let major = split.next();
     let minor = split.next();
@@ -61,15 +61,15 @@ fn parse_version(value: &str) -> Result<(u8, u8), HttpParseError> {
 
         Ok((major, minor))
     } else {
-        Err(HttpParseError::HeaderParseError)
+        Err(HttpError::HeaderParseError)
     }
 }
 
-fn parse_num(num_str: &str) -> Result<u8, HttpParseError> {
+fn parse_num(num_str: &str) -> Result<u8, HttpError> {
     if let Ok(num) = num_str.parse::<u8>() {
         Ok(num)
     } else {
-        Err(HttpParseError::HeaderParseError)
+        Err(HttpError::HeaderParseError)
     }
 }
 
@@ -93,7 +93,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_http_version() -> Result<(), HttpParseError> {
+    fn test_parse_http_version() -> Result<(), HttpError> {
         let src = "HTTP/1.0".to_string();
 
         let http_version: HttpVersion = src.try_into()?;

--- a/src/url/mod.rs
+++ b/src/url/mod.rs
@@ -1,0 +1,2 @@
+pub mod url_error;
+pub mod url_path;

--- a/src/url/url_error.rs
+++ b/src/url/url_error.rs
@@ -1,0 +1,4 @@
+#[derive(Debug)]
+pub enum UrlError {
+    PathParseError(&'static str),
+}

--- a/src/url/url_path.rs
+++ b/src/url/url_path.rs
@@ -140,7 +140,7 @@ mod tests {
 
         let result = parse_path(src).unwrap();
         assert_eq!(result.raw, src);
-        assert_eq!(result.pathname, "/abc/def-123/");
+        assert_eq!(result.pathname, "/abc/def-123");
         assert_eq!(result.query, None);
         assert_eq!(result.hash, None);
     }

--- a/src/url/url_path.rs
+++ b/src/url/url_path.rs
@@ -152,7 +152,7 @@ mod tests {
                 .to_vec()
                 .try_into()
                 .unwrap();
-        let url_path: UrlPath = http_request_header.try_into().unwrap();
+        let url_path: UrlPath = (&http_request_header).try_into().unwrap();
 
         assert_eq!(url_path.pathname, "/abc/def-123/");
         assert_eq!(url_path.query.unwrap(), "q1=123&q2=456");

--- a/src/url/url_path.rs
+++ b/src/url/url_path.rs
@@ -1,0 +1,161 @@
+use std::convert::{TryFrom, TryInto};
+
+use regex::Regex;
+
+use lazy_static::lazy_static;
+
+use crate::http::HttpRequestHeader;
+use crate::url::url_error::UrlError;
+
+#[derive(Debug)]
+pub struct UrlPath {
+    raw: String,
+    pathname: String,
+    query: Option<String>,
+    hash: Option<String>,
+}
+
+lazy_static! {
+    static ref PATH_REGEX: Regex =
+        Regex::new(r"([^?#\s]+)(?:\?([^?#\s]+))?(?:#([^\s]+))?").unwrap();
+}
+
+impl TryFrom<&str> for UrlPath {
+    type Error = UrlError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        parse_path(value)
+    }
+}
+
+impl TryFrom<&HttpRequestHeader> for UrlPath {
+    type Error = UrlError;
+
+    fn try_from(header: &HttpRequestHeader) -> Result<Self, Self::Error> {
+        header.get_req_url().try_into()
+    }
+}
+
+fn parse_path(path_str: &str) -> Result<UrlPath, UrlError> {
+    let regex = Regex::new(r"([^?#\s]+)(?:\?([^?#\s]+))?(?:#([^\s]+))?").unwrap();
+
+    let captures = if let Some(captures) = regex.captures(path_str) {
+        captures
+    } else {
+        return Err(UrlError::PathParseError(
+            "path does not match with path pattern",
+        ));
+    };
+
+    let pathname = if let Some(pathname) = captures.get(1) {
+        pathname.as_str().to_string()
+    } else {
+        return Err(UrlError::PathParseError(
+            "can't found pathname from the path",
+        ));
+    };
+
+    let query = if let Some(query) = captures.get(2) {
+        Some(query.as_str().to_string())
+    } else {
+        None
+    };
+
+    let hash = if let Some(hash) = captures.get(3) {
+        Some(hash.as_str().to_string())
+    } else {
+        None
+    };
+
+    let raw = path_str.to_string();
+
+    Ok(UrlPath {
+        raw,
+        pathname,
+        query,
+        hash,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::http::HttpError;
+
+    use super::*;
+
+    #[test]
+    fn test_regex() {
+        let src = r"/abc/def_123/?q1=123&q2=456#hash";
+
+        let captures = PATH_REGEX.captures(src).unwrap();
+        assert_eq!(captures.get(0).unwrap().as_str(), src);
+        assert_eq!(captures.get(1).unwrap().as_str(), "/abc/def_123/");
+        assert_eq!(captures.get(2).unwrap().as_str(), "q1=123&q2=456");
+        assert_eq!(captures.get(3).unwrap().as_str(), "hash");
+
+        let src = r"/abc/def_123";
+        let captures = PATH_REGEX.captures(src).unwrap();
+        assert_eq!(captures.get(0).unwrap().as_str(), src);
+        assert_eq!(captures.get(1).unwrap().as_str(), "/abc/def_123");
+        assert_eq!(captures.get(2), None);
+        assert_eq!(captures.get(3), None);
+    }
+
+    #[test]
+    fn test_parse_path() {
+        let src = r"/abc/def-123/?q1=123&q2=456#hash";
+
+        let result = parse_path(src).unwrap();
+        assert_eq!(result.raw, src);
+        assert_eq!(result.pathname, "/abc/def-123/");
+        assert_eq!(result.query.unwrap(), "q1=123&q2=456");
+        assert_eq!(result.hash.unwrap(), "hash");
+    }
+
+    #[test]
+    fn test_parse_path_only_query() {
+        let src = r"/abc/def-123/?q1=123&q2=456";
+
+        let result = parse_path(src).unwrap();
+        assert_eq!(result.raw, src);
+        assert_eq!(result.pathname, "/abc/def-123/");
+        assert_eq!(result.query.unwrap(), "q1=123&q2=456");
+        assert_eq!(result.hash, None);
+    }
+
+    #[test]
+    fn test_parse_path_only_hash() {
+        let src = r"/abc/def-123/#hash";
+
+        let result = parse_path(src).unwrap();
+        assert_eq!(result.raw, src);
+        assert_eq!(result.pathname, "/abc/def-123/");
+        assert_eq!(result.query, None);
+        assert_eq!(result.hash.unwrap(), "hash");
+    }
+
+    #[test]
+    fn test_parse_path_pathname_only() {
+        let src = r"/abc/def-123";
+
+        let result = parse_path(src).unwrap();
+        assert_eq!(result.raw, src);
+        assert_eq!(result.pathname, "/abc/def-123/");
+        assert_eq!(result.query, None);
+        assert_eq!(result.hash, None);
+    }
+
+    #[test]
+    fn test_from_http_request_header() {
+        let http_request_header: HttpRequestHeader =
+            b"GET /abc/def-123/?q1=123&q2=456#hash HTTP/1.1\r\n"
+                .to_vec()
+                .try_into()
+                .unwrap();
+        let url_path: UrlPath = http_request_header.try_into().unwrap();
+
+        assert_eq!(url_path.pathname, "/abc/def-123/");
+        assert_eq!(url_path.query.unwrap(), "q1=123&q2=456");
+        assert_eq!(url_path.hash.unwrap(), "hash");
+    }
+}

--- a/test/post.html
+++ b/test/post.html
@@ -6,7 +6,7 @@
 </head>
 <body>
     <h1>Send Post Request Test</h1>
-    <form method="post" action="http://127.0.0.1:8888/" enctype="multipart/form-data">
+    <form method="post" action="http://127.0.0.1:8888/?q=한글 입니다" enctype="multipart/form-data">
         <label for="file">file</label>
         <input type="file" name="file" id="file"><br>
         <label for="name">name</label>


### PR DESCRIPTION
 - parse request path

[#7]

request header 의 path 부분을 파싱하는 로직을 추가했습니다. 수정된 파일은 많지만 관련된 파일은 `url_path.rs` 뿐입니다. 정규식을 사용하기 위해 `regex` 와 `lazy_static` crate 을 dependencies 추가했습니다.
